### PR TITLE
Add forgotten dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "Shawn Inder <shawn@vigour.io>"
   ],
   "dependencies": {
-    "bubleify": "^0.5.1"
+    "bubleify": "^0.5.1",
+    "is-node": "^1.0.2"
   },
   "engines": {},
   "devDependencies": {


### PR DESCRIPTION
The package is not working now because of that.
Also is there a really big reason to use `bubleify` as a dependency for single `const` declaration? Mb it is better to do old-school `var` and make this package extremely lightweight?